### PR TITLE
Fix GitHub workflow to use ffjs

### DIFF
--- a/.github/workflows/linux-x86_64.yaml
+++ b/.github/workflows/linux-x86_64.yaml
@@ -34,7 +34,7 @@ jobs:
           cd build
           ../configure --disable-doc --enable-gpl --enable-static --disable-shared --disable-autodetect --disable-iconv --enable-zlib --enable-libxvid --enable-rtmidi --enable-libzmq --enable-sdl2 --enable-libxcb --enable-libdrm
           make -j$(nproc)
-          make -j$(nproc) qjs
+          make -j$(nproc) ffjs
 
       - name: Package binaries
         run: |
@@ -50,7 +50,7 @@ jobs:
           sed '/SDL2_VERSION/d'                         -i ffglitch_readme.txt
           cd build
           mkdir "${FULL_NAME}"
-          cp ffedit ffgac fflive qjs "${FULL_NAME}"
+          cp ffedit ffgac fflive ffjs "${FULL_NAME}"
           cp ../ffglitch_readme.txt "${FULL_NAME}"/readme.txt
           zip -9 -r "../${OUTPUT_FILE}" "${FULL_NAME}"
         shell: bash

--- a/.github/workflows/macos-aarch64.yaml
+++ b/.github/workflows/macos-aarch64.yaml
@@ -46,7 +46,7 @@ jobs:
           cd build
           ../configure --disable-doc --enable-gpl --enable-static --disable-shared --disable-autodetect --disable-iconv --enable-zlib --enable-rtmidi --enable-libzmq --enable-sdl2 --enable-avfoundation
           make -j$(sysctl -n hw.ncpu)
-          make -j$(sysctl -n hw.ncpu) qjs
+          make -j$(sysctl -n hw.ncpu) ffjs
 
       - name: Package binaries
         run: |
@@ -64,7 +64,7 @@ jobs:
           sed -i '' '/Xvid/d'                                 ffglitch_readme.txt
           cd build
           mkdir "${FULL_NAME}"
-          cp ffedit ffgac fflive qjs "${FULL_NAME}"
+          cp ffedit ffgac fflive ffjs "${FULL_NAME}"
           cp ../ffglitch_readme.txt "${FULL_NAME}"/readme.txt
           zip -9 -r "../${OUTPUT_FILE}" "${FULL_NAME}"
         shell: bash

--- a/.github/workflows/macos-x86_64.yaml
+++ b/.github/workflows/macos-x86_64.yaml
@@ -36,7 +36,7 @@ jobs:
           cd build
           ../configure --disable-doc --enable-gpl --enable-static --disable-shared --disable-autodetect --disable-iconv --enable-zlib --enable-libxvid --enable-rtmidi --enable-libzmq --enable-sdl2 --enable-avfoundation
           make -j$(sysctl -n hw.ncpu)
-          make -j$(sysctl -n hw.ncpu) qjs
+          make -j$(sysctl -n hw.ncpu) ffjs
 
       - name: Package binaries
         run: |
@@ -53,7 +53,7 @@ jobs:
           sed -i '' s/SDL2_VERSION/"${SDL2_VERSION}"/g        ffglitch_readme.txt
           cd build
           mkdir "${FULL_NAME}"
-          cp ffedit ffgac fflive qjs "${FULL_NAME}"
+          cp ffedit ffgac fflive ffjs "${FULL_NAME}"
           cp ../ffglitch_readme.txt "${FULL_NAME}"/readme.txt
           zip -9 -r "../${OUTPUT_FILE}" "${FULL_NAME}"
         shell: bash

--- a/.github/workflows/windows-x86_64.yaml
+++ b/.github/workflows/windows-x86_64.yaml
@@ -62,7 +62,7 @@ jobs:
           cd build
           ../configure --cross-prefix=x86_64-w64-mingw32- --arch=x86_64 --target-os=mingw64 --extra-ldflags=-static --pkg-config-flags=--static --disable-doc --enable-gpl --enable-static --disable-shared --disable-autodetect --disable-iconv --enable-zlib --enable-libxvid --enable-rtmidi --enable-libzmq --enable-sdl2
           make -j$(nproc)
-          make -j$(nproc) qjs.exe
+          make -j$(nproc) ffjs.exe
 
       - name: Package binaries
         run: |
@@ -79,7 +79,7 @@ jobs:
           sed s/SDL2_VERSION/"${SDL2_VERSION}"/g        -i ffglitch_readme.txt
           cd build
           mkdir "${FULL_NAME}"
-          cp ffedit.exe ffgac.exe fflive.exe qjs.exe "${FULL_NAME}"
+          cp ffedit.exe ffgac.exe fflive.exe ffjs.exe "${FULL_NAME}"
           cp ../ffglitch_readme.txt "${FULL_NAME}"/readme.txt
           zip -9 -r "../${OUTPUT_FILE}" "${FULL_NAME}"
         shell: bash


### PR DESCRIPTION
Update GitHub workflow files to replace references to 'qjs' with 'ffjs'.
